### PR TITLE
omit , at transactions

### DIFF
--- a/Frontend/src/app/services/currency-format-service.ts
+++ b/Frontend/src/app/services/currency-format-service.ts
@@ -14,7 +14,7 @@ export class CurrencyFormatService {
       'symbol',
       '1.0-0'
     );
-    return formatteAmount ? formatteAmount.replace('SEK', '').trim() : '0';
+    return formatteAmount ? formatteAmount.replace('SEK', '').replace(',',' ').trim() : '0';
   }
   getFormattedNegativeAmount(amount: number): string {
     const negativeAmount = -amount;
@@ -24,6 +24,6 @@ export class CurrencyFormatService {
       'symbol',
       '1.0-0'
     );
-    return formatteAmount ? formatteAmount.replace('SEK', '').trim() : '0';
+    return formatteAmount ? formatteAmount.replace('SEK', '').replace(',',' ').trim() : '0';
   }
 }


### PR DESCRIPTION
This pull request includes a small change to the `CurrencyFormatService` class in the `Frontend/src/app/services/currency-format-service.ts` file. The change modifies the `getFormattedAmount` and `getFormattedNegativeAmount` methods to replace commas with spaces in the formatted amount strings.

* [`Frontend/src/app/services/currency-format-service.ts`](diffhunk://#diff-54f0dcc028f4b632fcd33b481892a11f34d26c095a9696afcad87f038992541cL17-R17): Modified the `getFormattedAmount` and `getFormattedNegativeAmount` methods to replace commas with spaces in the formatted amount strings. [[1]](diffhunk://#diff-54f0dcc028f4b632fcd33b481892a11f34d26c095a9696afcad87f038992541cL17-R17) [[2]](diffhunk://#diff-54f0dcc028f4b632fcd33b481892a11f34d26c095a9696afcad87f038992541cL27-R27)